### PR TITLE
Update inversion-fixes.config

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -137,13 +137,6 @@ INVERT
 
 ================================
 
-calendar.google.com
-
-INVERT
-#:4.fc
-
-================================
-
 central.bitdefender.com
 
 INVERT


### PR DESCRIPTION
For me the account profile pictures showed correctly when I removed inversion fixes. I can't see it breaking anything, so I'd remove these lines.